### PR TITLE
Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,4 +18,3 @@ python:
    version: 3.7
    install:
    - requirements: docs/requirements.txt
-   - requirements: requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,10 +28,9 @@ autodoc_mock_imports = [
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ sphinx==4.1.1
 sphinx-rtd-theme==0.5.2
 sphinx-autodoc-typehints==1.12.0
 # Needed to get autodoc to link correctly
-# .
+#.


### PR DESCRIPTION
Fixed the RTD build issues. It turns out to have just been a matter of putting the root directory on the PYTHONPATH. RTD appears to be building docs correctly now. 