### PR TITLE
Relax scipy requirement to build on Python > 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 INSTALL_REQUIRES = [
     "numpy>=1.18.5",
-    "scipy==1.4.1",
+    "scipy>=1.4.1",
     "scikit-learn>=0.23.2",
     "absl-py>=0.13.0",
     "pybind11>=2.5.0",


### PR DESCRIPTION
Scipy 1.4.1 appears to be [incompatible with Python > 3.7][1]. Relaxing the exact version requirement makes it possible to install MuyGPyS on newer versions of Python.

[1]: https://github.com/scipy/scipy/blob/adc4f4f7bab120ccfab9383aba272954a0a12fb0/setup.py#L44-L46