### PR TITLE
Fix knot optimization

### DIFF
--- a/MuyGPyS/examples/classify.py
+++ b/MuyGPyS/examples/classify.py
@@ -447,25 +447,12 @@ def do_classify(
         >>> nn_kwargs = {"nn_method": "exact", "algorithm": "ball_tree"}
         >>> k_kwargs = {
         ...     "kernel": RBF(
-        ...          metric=IsotropicDistortion(
+        ...         metric=IsotropicDistortion(
         ...             l2,
         ...             length_scale=ScalarHyperparameter(1.0, (1e-2, 1e2)),
         ...         ),
         ...     ),
         ...     "eps": HomoscedasticNoise(1e-5),
-        ... )
-        >>> muygps, nbrs_lookup, surrogate_predictions = do_classify(
-        ...         test['input'],
-        ...         train['input'],
-        ...         train['output'],
-        ...         nn_count=30,
-        ...         batch_count=200,
-        ...         loss_method="log",
-        ...         obj_method="loo_crossval",
-        ...         opt_method="bayes",
-        ...         k_kwargs=k_kwargs,
-        ...         nn_kwargs=nn_kwargs,
-        ...         verbose=False,
         ... )
         >>> muygps, nbrs_lookup, surrogate_predictions = do_classify(
         ...         test['input'],
@@ -496,9 +483,6 @@ def do_classify(
         train_labels:
             A matrix of shape `(train_count, response_count)` whose rows consist
             of label vectors for the training data.
-        train_features:
-            A matrix of shape `(train_count, feature_count)` whose rows consist
-            of observation vectors of the testing data.
         nn_count:
             The number of nearest neighbors to employ.
         batch_count:

--- a/MuyGPyS/gp/distortion/embed.py
+++ b/MuyGPyS/gp/distortion/embed.py
@@ -30,7 +30,9 @@ def apply_distortion(distortion_fn: Callable, **length_scales):
                 inner_kwargs.setdefault(
                     ls,
                     _optional_invoke_param(
-                        length_scales[ls], batch_features=batch_features
+                        length_scales[ls],
+                        batch_features=batch_features,
+                        **kwargs,
                     ),
                 )
             outer_kwargs = {
@@ -54,11 +56,12 @@ def _optional_invoke_param(
         ScalarHyperparameter, HierarchicalNonstationaryHyperparameter, float
     ],
     batch_features: Optional[mm.ndarray] = None,
+    **kwargs,
 ) -> float:
     if isinstance(param, ScalarHyperparameter):
         return param()
     if isinstance(param, HierarchicalNonstationaryHyperparameter):
-        return param(batch_features)
+        return param(batch_features, **kwargs)
     return param
 
 

--- a/MuyGPyS/gp/hyperparameter/experimental/hierarchical_nonstationary.py
+++ b/MuyGPyS/gp/hyperparameter/experimental/hierarchical_nonstationary.py
@@ -78,9 +78,9 @@ class HierarchicalNonstationaryHyperparameter:
         for key, arg in kwargs.items():
             match = pattern.fullmatch(key)
             if match:
-                name = match.group(0)
+                name = match.group(1)
                 if name == self._name:
-                    index = int(match.group(1))
+                    index = int(match.group(2))
                     self._knot_value_params[index]._set_val(arg)
                     updated = True
         if updated:

--- a/docs/examples/nonstationary_tutorial.ipynb
+++ b/docs/examples/nonstationary_tutorial.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -11,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -42,6 +44,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -59,6 +62,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -66,6 +70,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -74,6 +79,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -102,6 +108,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -122,6 +129,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -146,6 +154,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -153,6 +162,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -174,6 +184,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -206,6 +217,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -223,6 +235,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -245,6 +258,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -264,6 +278,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -295,6 +310,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -313,6 +329,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -332,6 +349,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -351,6 +369,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -387,6 +406,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -394,6 +414,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -406,11 +427,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bounds = [1.0, 20.0]\n",
-    "knot_values_to_be_optimized = [ScalarHyperparameter(\"sample\", bounds)] * knot_count"
+    "bounds = [1.0, 25.0]\n",
+    "knot_values_to_be_optimized = [ScalarHyperparameter(\"sample\", bounds) for _ in range(knot_count)]"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -437,6 +459,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -470,6 +493,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -477,6 +501,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -596,13 +621,7 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "⚠️ _Note that the target is currently not sensitive to the `length_scale_knot#` parameters, which is most likely a bug_ ⚠️"
-   ]
-  },
-  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -638,13 +657,7 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "⚠️ _Note that the knot values are not actually getting optimized at the moment!_ ⚠️"
-   ]
-  },
-  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -668,6 +681,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
I fixed the bug that prevented the knots from being optimized.

However, the optimization is still not working properly since in the notebook it sets the knots to very small values, often matching the lower bound. I tried lowering the lower bound, e.g. when I set it to 0.01 we do get a sensical shape with slightly larger values for the first and last knot, but the uncertainty gets enormous.