### PR TITLE
added target_mask kwarg to optimizer functors that specifies which re…

### DIFF
--- a/MuyGPyS/optimize/chassis.py
+++ b/MuyGPyS/optimize/chassis.py
@@ -53,6 +53,7 @@ class OptimizeFn:
         batch_features: Optional[mm.ndarray] = None,
         loss_fn: LossFn = lool_fn,
         loss_kwargs: Dict = dict(),
+        target_mask: Optional[mm.ndarray] = None,
         verbose: bool = False,
         **kwargs,
     ):
@@ -85,6 +86,9 @@ class OptimizeFn:
             loss_kwargs:
                 A dictionary of additional keyword arguments to apply to the
                 :class:`~MuyGPyS.optimize.loss.LossFn`. Loss function specific.
+            target_mask:
+                An array of indices, listing the output dimensions of the
+                prediction to be used for optimization.
             verbose:
                 If True, print debug messages.
             kwargs:
@@ -102,6 +106,7 @@ class OptimizeFn:
             crosswise_diffs,
             pairwise_diffs,
             batch_features=batch_features,
+            target_mask=target_mask,
             loss_fn=loss_fn,
             loss_kwargs=loss_kwargs,
         )
@@ -115,6 +120,7 @@ class OptimizeFn:
         crosswise_diffs: mm.ndarray,
         pairwise_diffs: mm.ndarray,
         batch_features: Optional[mm.ndarray] = None,
+        target_mask: Optional[mm.ndarray] = None,
         loss_fn: LossFn = lool_fn,
         loss_kwargs: Dict = dict(),
         **kwargs,
@@ -146,6 +152,9 @@ class OptimizeFn:
                 batch elements.
             loss_fn:
                 The loss functor used to evaluate model performance.
+            target_mask:
+                An array of indices, listing the output dimensions of the
+                prediction to be used for optimization.
             loss_kwargs:
                 A dictionary of additional keyword arguments to apply to the
                 :class:`~MuyGPyS.optimize.loss.LossFn`. Loss function specific.
@@ -173,6 +182,7 @@ class OptimizeFn:
             batch_nn_targets,
             batch_targets,
             batch_features=batch_features,
+            target_mask=target_mask,
             loss_kwargs=loss_kwargs,
         )
 

--- a/MuyGPyS/optimize/objective.py
+++ b/MuyGPyS/optimize/objective.py
@@ -28,6 +28,7 @@ def make_loo_crossval_fn(
     batch_nn_targets: mm.ndarray,
     batch_targets: mm.ndarray,
     batch_features: Optional[mm.ndarray] = None,
+    target_mask: Optional[mm.ndarray] = None,
     loss_kwargs: Dict = dict(),
 ) -> Callable:
     """
@@ -71,6 +72,9 @@ def make_loo_crossval_fn(
         batch_features:
             Matrix of floats of shape `(batch_count, feature_count)` whose rows
             give the features for each batch element.
+        target_mask:
+            An array of indices, listing the output dimensions of the prediction
+            to be used for optimization.
         loss_kwargs:
             A dict listing any additional kwargs to pass to the loss function.
 
@@ -85,6 +89,7 @@ def make_loo_crossval_fn(
         scale_fn,
         batch_nn_targets,
         batch_targets,
+        target_mask=target_mask,
         **loss_kwargs,
     )
 

--- a/tests/experimental/shear.py
+++ b/tests/experimental/shear.py
@@ -354,7 +354,9 @@ class LibraryTestCase(DataTestCase):
 
         self.assertTrue(mm.allclose(posterior_variance[0], variance_flat))
 
-    def _opt_chassis(self, opt_model, batch_targets, batch_nn_targets):
+    def _opt_chassis(
+        self, opt_model, batch_targets, batch_nn_targets, **kwargs
+    ):
         shear_mse_optimized = Bayes_optimize(
             opt_model,
             batch_targets,
@@ -365,6 +367,7 @@ class LibraryTestCase(DataTestCase):
             verbose=False,
             init_points=5,
             n_iter=20,
+            **kwargs,
         )
 
         ls = shear_mse_optimized.kernel.deformation.length_scale()
@@ -391,8 +394,14 @@ class LibraryTest(LibraryTestCase):
         )
 
     def test_opt23(self):
+        batch_targets = self.batch_targets[:, 1:]
         batch_nn_targets = self.batch_nn_targets[:, 1:, :]
-        self._opt_chassis(self.model23, self.batch_targets, batch_nn_targets)
+        self._opt_chassis(
+            self.model23,
+            batch_targets,
+            batch_nn_targets,
+            target_mask=(1, 2),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…sponse indices of predictions to preserve during optimization. This makes it possible to train a GP on a set of observed covariates that differs from the set of prediction covariates, such as the shear kernel.