### PR TITLE
Add missing kwargs to optimize_scale

### DIFF
--- a/MuyGPyS/gp/muygps.py
+++ b/MuyGPyS/gp/muygps.py
@@ -369,7 +369,7 @@ class MuyGPS:
         return self._var_fn.get_opt_fn()
 
     def optimize_scale(
-        self, pairwise_diffs: mm.ndarray, nn_targets: mm.ndarray
+        self, pairwise_diffs: mm.ndarray, nn_targets: mm.ndarray, **kwargs
     ):
         """
         Optimize the value of the :math:`sigma^2` scale parameter.
@@ -394,7 +394,7 @@ class MuyGPS:
             A reference to this model with a freshly-optimized `scale`
             parameter.
         """
-        Kin = self.kernel(pairwise_diffs)
+        Kin = self.kernel(pairwise_diffs, **kwargs)
         opt_fn = self.scale.get_opt_fn(self)
         self.scale._set(opt_fn(Kin, nn_targets))
         self._make()


### PR DESCRIPTION
I ran into an error when trying to optimize the scale for a hierarchical model where I wasn't able to pass `batch_features` to the kernel. This fixes it.

Example usage:
```python
muygps = muygps.optimize_scale(batch_pairwise_diffs, batch_nn_targets, batch_features=batch_features)
```